### PR TITLE
Updates to compile with MinGW 7.2  + small fixes

### DIFF
--- a/include/gl/Camera.hpp
+++ b/include/gl/Camera.hpp
@@ -18,6 +18,8 @@
 
 #include <glm/glm.hpp>
 
+#undef M_PI
+#define M_PI 3.14159265358979323846
 #ifndef RADIANS_PER_DEGREES
 #define RADIANS_PER_DEGREES (M_PI / 180.0f)
 #endif

--- a/include/gl/OpenGL.hpp
+++ b/include/gl/OpenGL.hpp
@@ -21,7 +21,11 @@
 	#include <OpenGL/gl.h>
 #else
 	#ifdef __MINGW32__
-		#include <GL/glew.h>
+		#ifdef USE_GLAD
+			#include <GLAD/glad.h>
+		#else
+			#include <GL/glew.h>
+		#endif // USE_GLAD, else GLEW
 	#else
 		#include <GL/gl.h>
 	#endif

--- a/include/gl/Transformable.hpp
+++ b/include/gl/Transformable.hpp
@@ -18,6 +18,8 @@
 
 #include "RenderStates.hpp"
 
+#undef M_PI
+#define M_PI 3.14159265358979323846
 #ifndef RADIANS_PER_DEGREES
 #define RADIANS_PER_DEGREES (M_PI / 180.0f)
 #endif

--- a/source/core/Application.cpp
+++ b/source/core/Application.cpp
@@ -42,9 +42,15 @@ void Application::init() {
 
 void Application::initOpenGL() {
 #ifdef __MINGW32__
+#ifdef USE_GLAD
+	if(!gladLoadGL()) {
+		throw EXCEPTION("OpenGL init failed");
+	}
+#else
 	if(glewInit() != GLEW_OK) {
 		throw EXCEPTION("glew init failed");
 	}
+#endif // USE_GLAD, else GLEW
 #endif
 
 	glEnable(GL_BLEND);

--- a/source/core/CoreApplication.cpp
+++ b/source/core/CoreApplication.cpp
@@ -11,6 +11,8 @@
  *
  * =====================================================================================
  */
+#include <ctime>
+
 #include "CoreApplication.hpp"
 #include "Exception.hpp"
 // #include "GamePad.hpp"

--- a/source/world/BlockFurnace.cpp
+++ b/source/world/BlockFurnace.cpp
@@ -86,6 +86,6 @@ void BlockFurnace::onTick(const glm::ivec3 &blockPosition, Player &, Chunk &, Wo
 		data->inventory.setStack(1, 0, recipe->result().item().id(), outputStack.amount() + recipe->result().amount());
 	}
 
-	data->data = ticksRemaining | (currentBurnTime << 16) | ((u32)itemProgress << 32);
+	data->data = ticksRemaining | ((u32)currentBurnTime << 16) | ((u64)itemProgress << 32);
 }
 

--- a/source/world/Chunk.cpp
+++ b/source/world/Chunk.cpp
@@ -11,6 +11,8 @@
  *
  * =====================================================================================
  */
+#include <cstring>
+
 #include "Chunk.hpp"
 #include "GameClock.hpp"
 #include "Registry.hpp"

--- a/source/world/ChunkLightmap.cpp
+++ b/source/world/ChunkLightmap.cpp
@@ -11,6 +11,8 @@
  *
  * =====================================================================================
  */
+#include <cstring>
+
 #include "Chunk.hpp"
 #include "ChunkLightmap.hpp"
 #include "Registry.hpp"


### PR DESCRIPTION
Never made a PR before, I'm scared :O But I think it makes sense.

These are the changes I had to make for it to compile with MinGW 7.2 with [Glad](https://github.com/Dav1dde/glad) instead of GLEW. Added missing headers. Added support for option USE_GLAD.

Also fixed a bug with the furnace block. Shifting u16 by 16 (<<) is undefined behaviour in general I think. At least for me it doesn't do what it should. Same for u32.

Update: Added commit to `#undef M_PI` and redefine to ensure the same value for all compilers. I think that's a good idea, no?